### PR TITLE
Updated configuration to resolve errors that occur when the access token is manually passed in

### DIFF
--- a/sdk-output/configuration.ts
+++ b/sdk-output/configuration.ts
@@ -133,16 +133,15 @@ export class Configuration {
         this.tokenUrl = param.tokenUrl
         this.clientId = param.clientId;
         this.clientSecret = param.clientSecret;
-        const url = `${this.tokenUrl}`;
-        const formData = new FormData()
-        formData .append('grant_type', 'client_credentials')
-        formData .append('client_id', this.clientId)
-        formData .append('client_secret', this.clientSecret)
-
+        
         if (!this.accessToken) {
+            const url = `${this.tokenUrl}`;
+            const formData = new FormData()
+            formData.append('grant_type', 'client_credentials')
+            formData.append('client_id', this.clientId)
+            formData.append('client_secret', this.clientSecret)
             this.accessToken = this.getAccessToken(url, formData);
         }
-        
     }
 
     private getHomeParams(): ConfigurationParameters {


### PR DESCRIPTION
The below errors occur due to the access token being provided, and the clientID and Secret being left blank, but the constructor setup code still runs

```
TypeError: Cannot read properties of undefined (reading 'name')
    at FormData._getContentDisposition (C:\Users\Luke\Documents\GitHub\electron-identitynow-starter\node_modules\form-data\lib\form_data.js:227:40)
    at FormData._multiPartHeader (C:\Users\Luke\Documents\GitHub\electron-identitynow-starter\node_modules\form-data\lib\form_data.js:178:33)
    at FormData.append (C:\Users\Luke\Documents\GitHub\electron-identitynow-starter\node_modules\form-data\lib\form_data.js:71:21)
    at new Configuration (C:\Users\Luke\Documents\GitHub\electron-identitynow-starter\node_modules\sailpoint-api-client\dist\configuration.js:85:18)
    at Module.createConfiguration (C:\Users\Luke\Documents\GitHub\electron-identitynow-starter\src\lib\sailpoint\sdk.ts:4:20)
    at load (C:\Users\Luke\Documents\GitHub\electron-identitynow-starter\src\routes\home\form-integration\+page.server.ts:10:17)
    at Module.load_server_data (C:\Users\Luke\Documents\GitHub\electron-identitynow-starter\node_modules\@sveltejs\kit\src\runtime\server\page\load_data.js:61:41)
    at C:\Users\Luke\Documents\GitHub\electron-identitynow-starter\node_modules\@sveltejs\kit\src\runtime\server\page\index.js:140:19
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```