### PR TITLE
Added email field to ListWorkgroupMembers200ResponseInnerBeta interface

### DIFF
--- a/sdk-output/beta/api.ts
+++ b/sdk-output/beta/api.ts
@@ -14240,6 +14240,12 @@ export interface ListPredefinedSelectOptionsResponseBeta {
  */
 export interface ListWorkgroupMembers200ResponseInnerBeta {
     /**
+     * Workgroup member identity email.
+     * @type {string}
+     * @memberof ListWorkgroupMembers200ResponseInnerBeta
+     */
+    'email'?: string;
+    /**
      * Workgroup member identity DTO type.
      * @type {string}
      * @memberof ListWorkgroupMembers200ResponseInnerBeta


### PR DESCRIPTION
In this update, the email field has been added to the ListWorkgroupMembers200ResponseInnerBeta interface in the api.ts file. This field represents the workgroup member's email. This addition will allow us to handle the email information of workgroup members when dealing with the API responses.