### PR TITLE
Fix 5 bugs in templates, config, and hand-written files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ build:
 	rm -rf ./sdk-output/v2026
 	node sdk-resources/prescript.js api-specs/idn/v2026/paths
 	java -jar openapi-generator-cli.jar generate -i api-specs/idn/sailpoint-api.v2026.yaml -g typescript-axios -o sdk-output/v2026 --global-property skipFormModel=false,apiDocs=true,modelDocs=true --config sdk-resources/v2026-config.yaml --api-name-suffix V2026Api --model-name-suffix V2026
+	rm -rf ./sdk-output/generic
+	java -jar openapi-generator-cli.jar generate -i api-specs/idn/sailpoint-api.generic.yaml -g typescript-axios -o sdk-output/generic --global-property skipFormModel=false,apiDocs=true,modelDocs=true --config sdk-resources/generic-config.yaml
 
 .PHONY: test
 test:

--- a/sdk-output/configuration.ts
+++ b/sdk-output/configuration.ts
@@ -250,7 +250,7 @@ export class Configuration {
       }
     } catch (error) {
       console.error("Unable to fetch access token.  Aborting.");
-      throw new Error(error);
+      throw error;
     }
   }
 

--- a/sdk-resources/generic-config.yaml
+++ b/sdk-resources/generic-config.yaml
@@ -5,5 +5,5 @@ files:
     destinationFilename: package.json
 npmName: sailpoint-sdk
 npmRepository: sailpoint.com
-npmVersion: 1.6.7
+npmVersion: 1.7.22
 useSingleRequestParameter: true

--- a/sdk-resources/resources/baseApi.mustache
+++ b/sdk-resources/resources/baseApi.mustache
@@ -42,7 +42,7 @@ export class BaseAPI {
     constructor(configuration?: Configuration, protected basePath: string = BASE_PATH, protected axios: AxiosInstance = globalAxios) {
         if (configuration) {
             this.configuration = configuration;
-            this.basePath = configuration.basePath {{#apiVersion}}+ "/{{{apiVersion}}}"{{/apiVersion}}|| this.basePath;
+            this.basePath = (configuration.basePath != null ? (configuration.basePath {{#apiVersion}}+ "/{{{apiVersion}}}"{{/apiVersion}}) : undefined) || this.basePath;
         }
     }
 };

--- a/sdk-resources/resources/common.mustache
+++ b/sdk-resources/resources/common.mustache
@@ -137,7 +137,9 @@ export const toPathString = function (url: URL) {
  */
 export const createRequestFunction = function (axiosArgs: RequestArgs, globalAxios: AxiosInstance, BASE_PATH: string, configuration?: Configuration) {
     return <T = unknown, R = AxiosResponse<T>>(axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-        axiosRetry(axios, configuration.retriesConfig)
+        if (configuration?.retriesConfig) {
+            axiosRetry(axios, configuration.retriesConfig);
+        }
         const headers = {
             ...{'User-Agent':'OpenAPI-Generator/{{npmVersion}}/ts'}, 
             ...axiosArgs.axiosOptions.headers,
@@ -151,7 +153,7 @@ export const createRequestFunction = function (axiosArgs: RequestArgs, globalAxi
         }
 
         axiosArgs.axiosOptions.headers = headers
-        const axiosRequestArgs = {...axiosArgs.axiosOptions, url: (configuration?.basePath {{#apiVersion}}+ "/{{{apiVersion}}}"{{/apiVersion}} || basePath) + axiosArgs.url};
+        const axiosRequestArgs = {...axiosArgs.axiosOptions, url: ((configuration?.basePath != null ? (configuration.basePath {{#apiVersion}}+ "/{{{apiVersion}}}"{{/apiVersion}}) : undefined) || basePath) + axiosArgs.url};
         return axios.request<T, R>(axiosRequestArgs);
     };
 }


### PR DESCRIPTION
## Summary

Cross-SDK audit identified 5 bugs in the TypeScript SDK across mustache templates, build config, and hand-written files. Template fixes will propagate to generated code on next `make build`.

## Bug Fixes

### Critical

**T1: `undefined + "/v3"` produces `"undefined/v3"` — fallback `basePath` never triggers**
- [`sdk-resources/resources/baseApi.mustache` L45](https://github.com/sailpoint-oss/typescript-sdk/blob/fix/cross-sdk-bug-fixes/sdk-resources/resources/baseApi.mustache#L45): When `configuration.basePath` is `undefined`, the expression `configuration.basePath + "/v3"` evaluates to `"undefined/v3"` (a truthy string), so the `|| this.basePath` fallback never activates.
- **Fix:** Added explicit null check: `(configuration.basePath != null ? (configuration.basePath + "/{apiVersion}") : undefined) || this.basePath`.

**T2: Null dereference on optional `configuration` parameter**
- [`sdk-resources/resources/common.mustache` L140](https://github.com/sailpoint-oss/typescript-sdk/blob/fix/cross-sdk-bug-fixes/sdk-resources/resources/common.mustache#L140): `axiosRetry(axios, configuration.retriesConfig)` — no null check, but the `configuration` parameter is optional (`configuration?: Configuration`). When called without a configuration, this throws a null reference error.
- **Fix:** Wrapped in `if (configuration?.retriesConfig) { axiosRetry(axios, configuration.retriesConfig); }`.

**T3: Same operator precedence bug as T1 in request URL construction**
- [`sdk-resources/resources/common.mustache` L156](https://github.com/sailpoint-oss/typescript-sdk/blob/fix/cross-sdk-bug-fixes/sdk-resources/resources/common.mustache#L156): `configuration?.basePath + "/v3" || basePath` has the same `undefined + "/v3"` = `"undefined/v3"` problem.
- **Fix:** Same null-check pattern as T1.

### Medium

**T4: Generic package version `1.6.7` out of sync with other packages at `1.7.22`**
- [`sdk-resources/generic-config.yaml` L8](https://github.com/sailpoint-oss/typescript-sdk/blob/fix/cross-sdk-bug-fixes/sdk-resources/generic-config.yaml#L8): `npmVersion: 1.6.7` while all other packages (v3, beta, v2024, v2025, v2026) are at `1.7.22`.
- **Fix:** Updated to `1.7.22`.
- [`Makefile`](https://github.com/sailpoint-oss/typescript-sdk/blob/fix/cross-sdk-bug-fixes/Makefile#L24): Generic package was missing from the `build:` target.
- **Fix:** Added the generic build step.

### Low

**T5: `throw new Error(error)` destroys original stack trace**
- [`sdk-output/configuration.ts` L253](https://github.com/sailpoint-oss/typescript-sdk/blob/fix/cross-sdk-bug-fixes/sdk-output/configuration.ts#L253): Wrapping the caught error in `new Error(error)` loses the original stack trace and coerces the error to a string.
- **Fix:** Changed to `throw error` to preserve the original error object and stack.

## Verification

- Template fixes (T1-T3) verified by source inspection; will take effect on next `make build`
- T4 verified by comparing `npmVersion` across all `*-config.yaml` files
- T5: `npx tsc --noEmit` shows only pre-existing `esModuleInterop` errors unrelated to our changes

## Test plan

- [ ] Run `make build && npm run build` to verify generated code compiles with template fixes
- [ ] Test SDK initialization without explicit `basePath` to confirm fallback works correctly
- [ ] Verify generic package builds and has correct version after `make build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)